### PR TITLE
Plaka kontrolu sıkılaştırıldı

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@
             <div class="regex-item">
                 <h2>Araç Plakası</h2>
                 <h3>Kabul edilen formatlar</h3>
-                <p><i>34AD234<br>06J1238<br>45ASD234</i></p>
+                <p><i>34A2344<br>34A23415<br>06BK123<br>06JK1234<br>81ABC75</i></p>
                 <h3>Regex</h3>
-                <pre>/^([0-9]{2})([A-Z]{1,3})([0-9]{2,4})$/</pre>
+                <pre>/^(0[1-9]|[1-7][0-9]|8[01])(([A-Z])(\d{4,5})|([A-Z]{2})(\d{3,4})|([A-Z]{3})(\d{2,3}))$/</pre>
             </div>
             <div class="regex-item">
                 <h2>Doğum Tarihi</h2>

--- a/regex.js
+++ b/regex.js
@@ -43,11 +43,13 @@ function creditCardRegEx(val) {
 
 // Araç Plaka
 function carPlateRegEx(val) {
-    return /^([0-9]{2})([A-Z]{1,3})([0-9]{2,4})$/.test(val);
+    return /^(0[1-9]|[1-7][0-9]|8[01])(([A-Z])(\d{4,5})|([A-Z]{2})(\d{3,4})|([A-Z]{3})(\d{2,3}))$/.test(val);
     /*
-    34AD234
-    06J1238
-    45ASD234
+    34A2344
+    36A23415
+    06BK123
+    08JK1234
+    81ABC75
     */
 }
 


### PR DESCRIPTION
Closes #4 
İl kodu 81'e kadar olacak şekilde kısıtlandı. Plakalarda bulunmayan harf grubu ve sayı çiftlerini içermeyecek şekilde düzeltildi.

Düzeltilen örnek:
Önceki durumda `06ABC1234` eşleşirken artık eşleşmiyor.

Plakalar şu şekilde olabilir:

 ```
81X1234 81X12345
81XX123 81XX1234
81XXX12 81XXX123
```