### PR TITLE
Fix landline phone regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
             <div class="regex-item">
                 <h2>Sabit Telefonu Numarası</h2>
                 <h3>Kabul edilen formatlar</h3>
-                <p><i>01231231212<br>0123 123 12 12</i></p>
+                <p><i>02231231212<br>0223 123 12 12</i></p>
                 <h3>Regex</h3>
-                <pre>/^(0)([0-9]{3})\s?([0-9]{3})\s?([0-9]{2})\s?([0-9]{2})$/</pre>
+                <pre>/^(0)([2348]{1})([0-9]{2})\s?([0-9]{3})\s?([0-9]{2})\s?([0-9]{2})$/</pre>
             </div>
             <div class="regex-item">
                 <h2>TC Kimlik Numarası</h2>

--- a/regex.js
+++ b/regex.js
@@ -9,10 +9,10 @@ function mobilePhoneRegEx(val) {
 
 // Sabit Telefon Numarası
 function phoneRegEx(val) {
-    return /^(0)([0-9]{3})\s?([0-9]{3})\s?([0-9]{2})\s?([0-9]{2})$/.test(val);
+    return /^(0)([2348]{1})([0-9]{2})\s?([0-9]{3})\s?([0-9]{2})\s?([0-9]{2})$/.test(val);
     /*
-    01231231212
-    0123 123 12 12
+    02231231212
+    0223 123 12 12
     */
 }
 


### PR DESCRIPTION
For landline phones, only "2,3,4 and 8" digits are used for area codes as first digit.

- Digit 2: Western cities (Izmir 232, Bursa 224, Kocaeli 262 etc.)
- Digit 3: Intermediate cities (Ankara 312, Konya 332, Adana 322 etc.)
- Digit 4: Eastern cities (Diyarbakır 412, Van 432, Rize 464 etc.)
- Digit 8: Non-areal numbers (e.g 0850xxxxxxx)
